### PR TITLE
OutputtedNode Type

### DIFF
--- a/spec/phases/output.spec.ts
+++ b/spec/phases/output.spec.ts
@@ -2,6 +2,7 @@ import { loadContextTreeNode } from "../../src/phases/discovery.js";
 import { processNode } from "../../src/phases/processing.js";
 import {
     ContextTreeNode,
+    OutputtedNode,
     ProcessedNode,
     ResolvedNode,
 } from "../../src/types/nodes.js";
@@ -39,8 +40,8 @@ async function processTree() {
     });
     const outputDir: string = path.join(tempDir(), "output");
 
-    await outputNode(finalizedNode, outputDir);
-    return { outputDir: outputDir, node: finalizedNode };
+    const outputted = await outputNode(finalizedNode, outputDir);
+    return { outputDir: outputDir, node: outputted };
 }
 
 describe("The node outputter", () => {
@@ -139,5 +140,155 @@ describe("The node outputter", () => {
 
         expect(childOne).toBe("hello world");
         expect(childTwo).toBe("hello world");
+    });
+    it("should return file tree with pages at dir/index.html", async () => {
+        await makeTempFiles({
+            "tartan.context.default.json": JSON.stringify({
+                pageMode: "file",
+                pageSource: "source.md",
+                pagePattern: "*.md",
+            } as TartanContextFile),
+            "source.md": "source",
+            "child-one.md": "child one",
+            "child-two.md": "child two",
+        });
+
+        const { node } = await processTree();
+
+        expect(node).toEqual(
+            jasmine.objectContaining<OutputtedNode>({
+                type: "directory",
+                path: ".",
+                children: jasmine.arrayWithExactContents([
+                    jasmine.objectContaining<OutputtedNode>({
+                        type: "file",
+                        path: "index.html",
+                        size: 6,
+                    }),
+                    jasmine.objectContaining<OutputtedNode>({
+                        type: "directory",
+                        path: "child-one",
+                        children: jasmine.arrayWithExactContents([
+                            jasmine.objectContaining<OutputtedNode>({
+                                type: "file",
+                                path: "child-one/index.html",
+                                size: 9,
+                            }),
+                        ]),
+                    }),
+                    jasmine.objectContaining<OutputtedNode>({
+                        type: "directory",
+                        path: "child-two",
+                        children: jasmine.arrayWithExactContents([
+                            jasmine.objectContaining<OutputtedNode>({
+                                type: "file",
+                                path: "child-two/index.html",
+                                size: 9,
+                            }),
+                        ]),
+                    }),
+                ]),
+            }),
+        );
+    });
+    it("should return file tree with assets at their path", async () => {
+        const tmpDir: string = await makeTempFiles({
+            "tartan.context.default.json": JSON.stringify({
+                pageMode: "asset",
+                pageSource: "source.md",
+                pagePattern: "*.png",
+            } as TartanContextFile),
+            "source.md": "source",
+            "child-one.png": "child one", // ik totally a png :p
+            "child-two.png": "child two",
+        });
+
+        const { node } = await processTree();
+
+        expect(node).toEqual(
+            jasmine.objectContaining<OutputtedNode>({
+                type: "directory",
+                path: ".",
+                children: jasmine.arrayWithExactContents([
+                    jasmine.objectContaining<OutputtedNode>({
+                        type: "file",
+                        path: "index.html",
+                        size: 6,
+                    }),
+                    jasmine.objectContaining<OutputtedNode>({
+                        type: "file",
+                        path: "child-one.png",
+                        size: 9,
+                    }),
+                    jasmine.objectContaining<OutputtedNode>({
+                        type: "file",
+                        path: "child-two.png",
+                        size: 9,
+                    }),
+                ]),
+            }),
+        );
+    });
+    it("should return file tree containing files outputted by handoff nodes", async () => {
+        await makeTempFiles({
+            "handoff.js": `import fs from "fs/promises"; import path from "path"; export default {finalize: async (input) => {
+                if (input.thisNode.type === "handoff.file") {
+                    await fs.writeFile(path.join(input.stagingDirectory, "finalized"), "hello world");
+                }
+                else if (input.thisNode.type === "handoff") {
+                    await fs.mkdir(path.join(input.stagingDirectory, "finalized"), {recursive: true});
+                    await fs.writeFile(path.join(input.stagingDirectory, "finalized", "testfile"), "hello world");
+                }
+                return {};
+            }}`,
+            "tartan.context.default.json": JSON.stringify({
+                pageMode: "asset",
+                pageSource: "source.md",
+                pagePattern: "*.png",
+                handoffHandler: "./handoff.js",
+            } as TartanContextFile),
+            "asset.png": "a random asset but it'll be handoffed... handed off?",
+            "asset.png.context.json": JSON.stringify({
+                pageMode: "handoff",
+            } as TartanContextFile),
+            "child/tartan.context.json": JSON.stringify({
+                pageMode: "handoff",
+            } as TartanContextFile),
+        });
+
+        const { outputDir, node } = await processTree();
+
+        const childOne: string = await fs
+            .readFile(path.join(outputDir, "asset.png"))
+            .then((val) => val.toString());
+        const childTwo: string = await fs
+            .readFile(path.join(outputDir, "child/testfile"))
+            .then((val) => val.toString());
+
+        expect(childOne).toBe("hello world");
+        expect(childTwo).toBe("hello world");
+
+        expect(node).toEqual({
+            type: "directory",
+            path: ".",
+            children: jasmine.arrayWithExactContents([
+                jasmine.objectContaining<OutputtedNode>({
+                    type: "file",
+                    path: "asset.png",
+                    size: 11,
+                }),
+                {
+                    type: "directory",
+                    path: "child",
+                    children: [
+                        jasmine.objectContaining<OutputtedNode>({
+                            type: "file",
+                            path: "child/testfile",
+                            size: 11,
+                        }),
+                    ],
+                },
+            ]),
+        });
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,12 @@ import { finalizeNode } from "./phases/finalizing.js";
 import { outputNode } from "./phases/output.js";
 import { processNode } from "./phases/processing.js";
 import { resolveNode } from "./phases/resolving.js";
-import { ContextTreeNode, ProcessedNode, ResolvedNode } from "./types/nodes.js";
+import {
+    ContextTreeNode,
+    OutputtedNode,
+    ProcessedNode,
+    ResolvedNode,
+} from "./types/nodes.js";
 import { FullTartanContext } from "./types/tartan-context.js";
 import { createLogger } from "winston";
 import { NullTransport } from "./types/logs.js";
@@ -21,7 +26,7 @@ export async function build(
     outputDirectory: string,
     rootContext: FullTartanContext,
     loggerTransports?: TransportStream[],
-): Promise<ResolvedNode> {
+): Promise<OutputtedNode> {
     const baseLogger = createLogger({
         transports: loggerTransports ?? [new NullTransport()],
     });

--- a/src/phases/output.ts
+++ b/src/phases/output.ts
@@ -1,6 +1,8 @@
-import { ResolvedNode } from "../types/nodes.js";
+import { OutputtedNode, ResolvedNode } from "../types/nodes.js";
 import fs from "fs/promises";
+import { Dirent } from "node:fs";
 import path from "node:path";
+import { inspect } from "node:util";
 
 /**
  * Output all the finalized files of this node and it's children into the output directory.
@@ -9,54 +11,99 @@ import path from "node:path";
  * @argument outputDirectory The root output directory.
  */
 export async function outputNode(
-    node: ResolvedNode,
-    outputDirectory: string,
-): Promise<ResolvedNode> {
-    const logger = node.logger.child({ phase: "output" });
-    logger.info("copying finalized source to output directory");
-    if (node.type === "page" || node.type === "page.file") {
-        logger.debug("creating output directory for page");
-        await fs.mkdir(path.join(path.join(outputDirectory, node.outputPath)), {
-            recursive: true,
-        });
-        logger.debug("copying to index.html");
-        await fs.copyFile(
-            path.join(node.stagingDirectory, "finalized"),
-            path.join(outputDirectory, node.outputPath, "index.html"),
+    rootNode: ResolvedNode,
+    outputDir: string,
+): Promise<OutputtedNode> {
+    /*
+     * Set up stuff for simpler tree construction
+     */
+    const rootOutput: OutputtedNode = {
+        path: ".",
+        type: "directory",
+        children: [],
+    };
+    const createdDirs: {
+        [key: string]: OutputtedNode;
+    } = { ".": rootOutput };
+    const outputFile = async (
+        sourcePath: string,
+        outputPath: string, // relative to output directory
+    ): Promise<void> => {
+        const paths: string[] = outputPath
+            .split(path.sep)
+            .map((_, i, arr) => path.join(...arr.slice(0, i + 1)));
+        for (let i = 0; i < paths.length; i++) {
+            const val = paths[i];
+            if (!Object.hasOwn(createdDirs, val)) {
+                let node: OutputtedNode =
+                    i < paths.length - 1 // all but the last are directories
+                        ? { path: val, type: "directory", children: [] }
+                        : {
+                              path: val,
+                              type: "file",
+                              children: [],
+                              size: await fs
+                                  .stat(sourcePath)
+                                  .then((stat) => stat.size),
+                          };
+                createdDirs[path.dirname(val)].children.push(node);
+                if (node.type === "directory") createdDirs[node.path] = node;
+            }
+        }
+
+        const resolvedOutput = path.join(outputDir, outputPath);
+        await fs.mkdir(path.dirname(resolvedOutput), { recursive: true });
+        await fs.copyFile(sourcePath, resolvedOutput);
+    };
+
+    /*
+     * Output the nodes
+     */
+    const queue: ResolvedNode[] = [rootNode];
+
+    while (queue.length > 0) {
+        const node: ResolvedNode = queue.pop() as ResolvedNode;
+        queue.push(...node.children);
+        const logger = node.logger.child({ phase: "output" });
+        logger.info(`copying finalized source to ${outputDir}`);
+
+        const sourcePath: string = path.join(
+            node.stagingDirectory,
+            "finalized",
         );
-    } else if (node.type === "asset" || node.type === "handoff.file") {
-        logger.debug("creating parent directory for file");
-        await fs.mkdir(
-            path.dirname(path.join(outputDirectory, node.outputPath)),
-            { recursive: true },
-        );
-        logger.debug("copying file to output path");
-        await fs.copyFile(
-            path.join(node.stagingDirectory, "finalized"),
-            path.join(outputDirectory, node.outputPath),
-        );
-    } else if (node.type === "handoff") {
-        logger.debug("creating output directory for handoff node");
-        await fs.mkdir(
-            path.dirname(path.join(outputDirectory, node.outputPath)),
-            { recursive: true },
-        );
-        logger.debug(
-            "copying entire finalized directory tree to output directory",
-        );
-        await fs.cp(
-            path.join(node.stagingDirectory, "finalized"),
-            path.join(outputDirectory, node.outputPath),
-            { recursive: true },
-        );
+        if (node.type === "page" || node.type === "page.file") {
+            const outputPath: string = path.join(node.outputPath, "index.html");
+            logger.debug(`copying to ${outputPath}`);
+            await outputFile(sourcePath, outputPath);
+        } else if (node.type === "asset" || node.type === "handoff.file") {
+            const outputPath: string = node.outputPath;
+            logger.debug(`copying to ${outputPath}`);
+            await outputFile(sourcePath, outputPath);
+        } else if (node.type === "handoff") {
+            const entries: Dirent<string>[] = await fs.readdir(sourcePath, {
+                withFileTypes: true,
+                recursive: true,
+            });
+
+            for (const entry of entries) {
+                if (!entry.isFile()) continue;
+
+                const filePath: string = path.join(
+                    entry.parentPath,
+                    entry.name,
+                );
+                const relativePath = path.relative(sourcePath, filePath);
+                const outputPath: string = path.join(
+                    node.outputPath,
+                    relativePath,
+                );
+                logger.debug(
+                    `outputting file ${relativePath} to ${outputPath}`,
+                );
+                await outputFile(filePath, outputPath);
+            }
+        }
     }
 
-    logger.info("waiting for children to output");
-    await Promise.all(
-        node.children.map((child) => outputNode(child, outputDirectory)),
-    );
-
-    logger.info("finished outputting");
-
-    return node;
+    return rootOutput;
 }

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -108,3 +108,16 @@ export type ResolvedNode = Omit<ProcessedNode, "outputPath" | "children"> & {
     outputPath: string;
     children: ResolvedNode[];
 };
+
+export type OutputtedNode = {
+    /**
+     * The path of this fs object, relative to the base output directory
+     */
+    path: string;
+    type: "directory" | "file";
+    children: OutputtedNode[];
+    /**
+     * The size, in bytes, of the output (if it was a file)
+     */
+    size?: number;
+};


### PR DESCRIPTION
An `OutputtedNode` describes a filesystem object (either a file or directory), and as a whole represents the outputted file tree.