### PR TITLE
Feature: serialize

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,6 @@
 - Hide accidental exports (context schema) (hell maybe I should ditch the whole schema thing completely and go pure TS. I can generate schemas at build time if I really need)
 - Export version info (for downstream client consumption so they don't have to do garbage with `package.json` finding)
 - rename `loadContextTreeNode` to fit it's phase name
-- Add `TartanConfig` to the core library
 - Serializable and deserializable context trees
     - allow specifying multiple sources for an input (like `esbuild` listing imports or a context object listing it's parents)
     - add a timestamp/hash for sources

--- a/TODO.md
+++ b/TODO.md
@@ -18,3 +18,4 @@
     - I think it has to be handled by the source processors themselves, cause things like esbuild are able to manage multiple files and efficient rebuilds, in a way that would be needlessly complex to implement on the tartan side.
 - Should `TartanInput` have a property that's a function to reload the value?
     - Probably not. I think that's premature optimization. All the actually hard computations happen in source processors.
+- Parameters to define cache and staging directories.

--- a/spec/inputs/context.spec.ts
+++ b/spec/inputs/context.spec.ts
@@ -23,25 +23,26 @@ describe("The context initializer", () => {
             handoffHandler: "./handoff.js",
         };
 
-        const tartanContextFile = {
+        const tartanContextFile: TartanInput<TartanContextFile> = {
             value: context,
             url: pathToFileURL(path.join(tmpDir, "tartan.context")),
+            hash: "",
+            type: "json",
         };
-        const initialized: TartanInput<PartialTartanContext> =
-            await initializeContext(
-                {
-                    "~source-directory": tmpDir,
-                },
-                tartanContextFile,
-                nullLogger
-            );
+        const initialized: PartialTartanContext = await initializeContext(
+            {
+                "~source-directory": tmpDir,
+            },
+            tartanContextFile,
+            nullLogger,
+        );
 
-        expect(initialized.value.sourceProcessors).toBeDefined();
-        expect(initialized.value.handoffHandler).toBeDefined();
+        expect(initialized.sourceProcessors).toBeDefined();
+        expect(initialized.handoffHandler).toBeDefined();
         // @ts-ignore
-        expect(initialized.value.sourceProcessors[0].value.process()).toBe(42); // the answer to life the universe and everything
+        expect(initialized.sourceProcessors[0].value.process()).toBe(42); // the answer to life the universe and everything
         // @ts-ignore
-        expect(initialized.value.handoffHandler.value.process()).toBe(84); // twice the answer idk lol
+        expect(initialized.handoffHandler.value.process()).toBe(84); // twice the answer idk lol
     });
     it("should load the asset processors", async () => {
         const tmpDir = await makeTempFiles({
@@ -59,24 +60,25 @@ describe("The context initializer", () => {
         const contextFile: TartanInput<TartanContextFile> = {
             value: context,
             url: new URL(path.join(tmpDir, "tartan.context"), "file://"),
+            hash: "",
+            type: "json",
         };
-        const initialized: TartanInput<PartialTartanContext> =
-            await initializeContext(
-                {
-                    "~source-directory": tmpDir,
-                },
-                contextFile,
-                nullLogger
-            );
+        const initialized: PartialTartanContext = await initializeContext(
+            {
+                "~source-directory": tmpDir,
+            },
+            contextFile,
+            nullLogger,
+        );
 
-        expect(initialized.value.assetProcessors).toBeDefined();
-        expect(initialized.value.assetProcessors).toEqual({
+        expect(initialized.assetProcessors).toBeDefined();
+        expect(initialized.assetProcessors).toEqual({
             png: [jasmine.objectContaining({ value: jasmine.any(Function) })],
             jpg: [jasmine.objectContaining({ value: jasmine.any(Function) })],
         });
         expect(
             (
-                initialized.value.assetProcessors as Record<
+                initialized.assetProcessors as Record<
                     string,
                     TartanInput<Function>[]
                 >
@@ -84,7 +86,7 @@ describe("The context initializer", () => {
         ).toBe(42);
         expect(
             (
-                initialized.value.assetProcessors as Record<
+                initialized.assetProcessors as Record<
                     string,
                     TartanInput<Function>[]
                 >

--- a/spec/phases/output.spec.ts
+++ b/spec/phases/output.spec.ts
@@ -2,6 +2,7 @@ import { loadContextTreeNode } from "../../src/phases/discovery.js";
 import { processNode } from "../../src/phases/processing.js";
 import {
     ContextTreeNode,
+    FinalizedNode,
     OutputtedNode,
     ProcessedNode,
     ResolvedNode,
@@ -34,7 +35,7 @@ async function processTree() {
         baseLogger: nullLogger,
     });
     const resolvedNode: ResolvedNode = resolveNode(processedNode);
-    const finalizedNode: ResolvedNode = await finalizeNode({
+    const finalizedNode: FinalizedNode = await finalizeNode({
         node: resolvedNode,
         sourceDirectory: tempDir(),
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,17 +22,22 @@ export type BuildResult = {
     finalized: BuiltPhase<FinalizedNode>;
     outputted: BuiltPhase<OutputtedNode>;
 };
-export type BuiltPhase<
-    T extends
-        | ContextTreeNode
-        | ProcessedNode
-        | ResolvedNode
-        | FinalizedNode
-        | OutputtedNode,
-> = {
-    tree: T;
-    serialized: string;
+
+export type TartanConfig = {
+    /**
+     * The directory to load the root node from (will be loaded as a page)
+     */
+    sourceDirectory: string;
+    /**
+     * The directory to output the generated site to.
+     */
+    outputDirectory: string;
+    /**
+     * The context object for nodes to inherit from if not their parent.
+     */
+    rootContext: FullTartanContext;
 };
+
 /**
  * A helper function that calls each phase in sequence and returns the root ResolvedNode
  *
@@ -41,11 +46,13 @@ export type BuiltPhase<
  * @argument rootContext The context for nodes to inherit from if not their parent.
  */
 export async function build(
-    sourceDirectory: string,
-    outputDirectory: string,
-    rootContext: FullTartanContext,
+    config: TartanConfig,
+    /**
+     * Tranports for winston logs. If not provided,
+     */
     loggerTransports?: TransportStream[],
 ): Promise<BuildResult> {
+    const { sourceDirectory, outputDirectory, rootContext } = config;
     const baseLogger = createLogger({
         transports: loggerTransports ?? [new NullTransport()],
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { processNode } from "./phases/processing.js";
 import { resolveNode } from "./phases/resolving.js";
 import {
     ContextTreeNode,
+    FinalizedNode,
     OutputtedNode,
     ProcessedNode,
     ResolvedNode,
@@ -14,6 +15,24 @@ import { FullTartanContext } from "./types/tartan-context.js";
 import { createLogger } from "winston";
 import { NullTransport } from "./types/logs.js";
 
+export type BuildResult = {
+    discovered: BuiltPhase<ContextTreeNode>;
+    processed: BuiltPhase<ProcessedNode>;
+    resolved: BuiltPhase<ResolvedNode>;
+    finalized: BuiltPhase<FinalizedNode>;
+    outputted: BuiltPhase<OutputtedNode>;
+};
+export type BuiltPhase<
+    T extends
+        | ContextTreeNode
+        | ProcessedNode
+        | ResolvedNode
+        | FinalizedNode
+        | OutputtedNode,
+> = {
+    tree: T;
+    serialized: string;
+};
 /**
  * A helper function that calls each phase in sequence and returns the root ResolvedNode
  *
@@ -26,7 +45,7 @@ export async function build(
     outputDirectory: string,
     rootContext: FullTartanContext,
     loggerTransports?: TransportStream[],
-): Promise<OutputtedNode> {
+): Promise<BuildResult> {
     const baseLogger = createLogger({
         transports: loggerTransports ?? [new NullTransport()],
     });
@@ -42,14 +61,35 @@ export async function build(
         baseLogger,
     });
     const resolved: ResolvedNode = resolveNode(processed);
-    const finalized: ResolvedNode = await finalizeNode({
+    const finalized: FinalizedNode = await finalizeNode({
         node: resolved,
         sourceDirectory: sourceDirectory,
     });
 
     const outputted = await outputNode(finalized, outputDirectory);
 
-    return outputted;
+    return {
+        discovered: {
+            tree: node,
+            serialized: JSON.stringify(node),
+        },
+        processed: {
+            tree: processed,
+            serialized: JSON.stringify(processed),
+        },
+        resolved: {
+            tree: resolved,
+            serialized: JSON.stringify(resolved),
+        },
+        finalized: {
+            tree: finalized,
+            serialized: JSON.stringify(finalized),
+        },
+        outputted: {
+            tree: outputted,
+            serialized: JSON.stringify(outputted),
+        },
+    };
 }
 
 // Export all the phases
@@ -66,6 +106,7 @@ export * from "./types/tartan-context.js";
 export * from "./types/nodes.js";
 export * from "./types/inputs.js";
 export * from "./types/logs.js";
+export * from "./types/serialized.js";
 
 // Other stuff to assist UIs
 export { loadObject } from "./inputs/file-object.js"; // to load config and stuff

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,11 +16,11 @@ import { createLogger } from "winston";
 import { NullTransport } from "./types/logs.js";
 
 export type BuildResult = {
-    discovered: BuiltPhase<ContextTreeNode>;
-    processed: BuiltPhase<ProcessedNode>;
-    resolved: BuiltPhase<ResolvedNode>;
-    finalized: BuiltPhase<FinalizedNode>;
-    outputted: BuiltPhase<OutputtedNode>;
+    discovered: ContextTreeNode;
+    processed: ProcessedNode;
+    resolved: ResolvedNode;
+    finalized: FinalizedNode;
+    outputted: OutputtedNode;
 };
 
 export type TartanConfig = {
@@ -56,13 +56,13 @@ export async function build(
     const baseLogger = createLogger({
         transports: loggerTransports ?? [new NullTransport()],
     });
-    const node: ContextTreeNode = await loadContextTreeNode({
+    const discovered: ContextTreeNode = await loadContextTreeNode({
         directory: sourceDirectory,
         rootContext: rootContext,
         baseLogger,
     });
     const processed: ProcessedNode = await processNode({
-        node,
+        node: discovered,
         rootContext: rootContext,
         sourceDirectory: sourceDirectory,
         baseLogger,
@@ -76,26 +76,11 @@ export async function build(
     const outputted = await outputNode(finalized, outputDirectory);
 
     return {
-        discovered: {
-            tree: node,
-            serialized: JSON.stringify(node),
-        },
-        processed: {
-            tree: processed,
-            serialized: JSON.stringify(processed),
-        },
-        resolved: {
-            tree: resolved,
-            serialized: JSON.stringify(resolved),
-        },
-        finalized: {
-            tree: finalized,
-            serialized: JSON.stringify(finalized),
-        },
-        outputted: {
-            tree: outputted,
-            serialized: JSON.stringify(outputted),
-        },
+        discovered,
+        processed,
+        resolved,
+        finalized,
+        outputted,
     };
 }
 

--- a/src/inputs/context.ts
+++ b/src/inputs/context.ts
@@ -21,7 +21,7 @@ export async function initializeContext(
     initialPrefixMap: PrefixMap,
     contextFile: TartanInput<TartanContextFile>,
     logger: Logger,
-): Promise<TartanInput<PartialTartanContext>> {
+): Promise<PartialTartanContext> {
     logger.debug("resolving path prefixes");
     const resolvedPathPrefixes: Record<string, string> | undefined = contextFile
         .value.pathPrefixes
@@ -106,15 +106,10 @@ export async function initializeContext(
         : undefined;
 
     return {
-        value: {
-            ...contextFile.value,
-            ...(sourceProcessors ? { sourceProcessors } : {}),
-            ...(handoffHandler ? { handoffHandler } : {}),
-            ...(assetProcessors ? { assetProcessors } : {}),
-            ...(resolvedPathPrefixes
-                ? { pathPrefixes: resolvedPathPrefixes }
-                : {}),
-        } as PartialTartanContext,
-        url: contextFile.url,
-    };
+        ...contextFile.value,
+        ...(sourceProcessors ? { sourceProcessors } : {}),
+        ...(handoffHandler ? { handoffHandler } : {}),
+        ...(assetProcessors ? { assetProcessors } : {}),
+        ...(resolvedPathPrefixes ? { pathPrefixes: resolvedPathPrefixes } : {}),
+    } as PartialTartanContext;
 }

--- a/src/inputs/file-object.ts
+++ b/src/inputs/file-object.ts
@@ -81,26 +81,26 @@ export async function loadObject<T>(
         return {
             value: defaultIfNoFileExists,
             url: resolvedFilename,
+            hash: "",
+            type: "default",
         };
     }
 
     if (moduleFileExtensions.has(pathToLoad.ext)) {
         logger.debug(`trying to load ${path.format(pathToLoad)} as a module`);
+        const module = await loadModule<T>(
+            pathToFileURL(path.format(pathToLoad)),
+            logger,
+        );
         return {
-            value: await loadModule<T>(
-                pathToFileURL(path.format(pathToLoad)),
-                logger,
-            ).then(
-                (val) => val.value as T, // ignore the module path, instead setting it to resolvedBasename
-            ),
+            value: module.value,
             url: resolvedFilename,
+            hash: module.hash,
+            type: module.type,
         };
     } else if (pathToLoad.ext === ".json") {
         logger.debug(`trying to load ${path.format(pathToLoad)} as JSON`);
-        return {
-            value: await loadJSON(pathToFileURL(path.format(pathToLoad))),
-            url: resolvedFilename,
-        };
+        return await loadJSON(pathToFileURL(path.format(pathToLoad)));
     } else {
         logger.error(
             `can't load ${path.format(pathToLoad)}, incompatible file type`,
@@ -109,7 +109,13 @@ export async function loadObject<T>(
     }
 }
 
-export async function loadJSON<T>(fileURL: URL): Promise<T> {
-    // TODO: object cacheing to reduce disk io
-    return loadFile(fileURL).then((val) => JSON.parse(val.value.toString()));
+export async function loadJSON<T>(fileURL: URL): Promise<TartanInput<T>> {
+    const file: TartanInput<Buffer> = await loadFile(fileURL);
+
+    return {
+        value: JSON.parse(file.value.toString()),
+        url: file.url,
+        hash: file.hash, // I'll implement merkle tree hashing later, maybe... (https://github.com/tartan-generator/core/issues/10)
+        type: "json",
+    };
 }

--- a/src/inputs/file-object.ts
+++ b/src/inputs/file-object.ts
@@ -78,12 +78,12 @@ export async function loadObject<T>(
 
     if (pathToLoad === undefined) {
         logger.debug("falling back to default value");
-        return {
-            value: defaultIfNoFileExists,
-            url: resolvedFilename,
-            hash: "",
-            type: "default",
-        };
+        return new TartanInput(
+            defaultIfNoFileExists,
+            resolvedFilename,
+            "",
+            "default",
+        );
     }
 
     if (moduleFileExtensions.has(pathToLoad.ext)) {
@@ -92,15 +92,15 @@ export async function loadObject<T>(
             pathToFileURL(path.format(pathToLoad)),
             logger,
         );
-        return {
-            value: module.value,
-            url: resolvedFilename,
-            hash: module.hash,
-            type: module.type,
-        };
+        module.url = resolvedFilename;
+        return module;
     } else if (pathToLoad.ext === ".json") {
         logger.debug(`trying to load ${path.format(pathToLoad)} as JSON`);
-        return await loadJSON(pathToFileURL(path.format(pathToLoad)));
+        const val: TartanInput<T> = await loadJSON(
+            pathToFileURL(path.format(pathToLoad)),
+        );
+        val.url = resolvedFilename;
+        return val;
     } else {
         logger.error(
             `can't load ${path.format(pathToLoad)}, incompatible file type`,
@@ -112,10 +112,10 @@ export async function loadObject<T>(
 export async function loadJSON<T>(fileURL: URL): Promise<TartanInput<T>> {
     const file: TartanInput<Buffer> = await loadFile(fileURL);
 
-    return {
-        value: JSON.parse(file.value.toString()),
-        url: file.url,
-        hash: file.hash, // I'll implement merkle tree hashing later, maybe... (https://github.com/tartan-generator/core/issues/10)
-        type: "json",
-    };
+    return new TartanInput(
+        JSON.parse(file.value.toString()),
+        file.url,
+        file.hash, // I'll implement merkle tree hashing later, maybe... (https://github.com/tartan-generator/core/issues/10)
+        "json",
+    );
 }

--- a/src/inputs/file.ts
+++ b/src/inputs/file.ts
@@ -5,10 +5,5 @@ import { hash } from "crypto";
 
 export async function loadFile(url: URL): Promise<TartanInput<Buffer>> {
     const contents: Buffer = await fs.readFile(url.pathname);
-    return {
-        url,
-        value: contents,
-        hash: hash("sha256", contents),
-        type: "raw",
-    };
+    return new TartanInput(contents, url, hash("sha256", contents), "raw");
 }

--- a/src/inputs/file.ts
+++ b/src/inputs/file.ts
@@ -1,10 +1,14 @@
 import { URL } from "url";
 import { TartanInput } from "../types/inputs.js";
 import fs from "fs/promises";
+import { hash } from "crypto";
 
 export async function loadFile(url: URL): Promise<TartanInput<Buffer>> {
+    const contents: Buffer = await fs.readFile(url.pathname);
     return {
         url,
-        value: await fs.readFile(url.pathname),
+        value: contents,
+        hash: hash("sha256", contents),
+        type: "raw",
     };
 }

--- a/src/inputs/module.ts
+++ b/src/inputs/module.ts
@@ -57,6 +57,8 @@ export async function loadModule<T>(
     return {
         url: moduleURL,
         value: defaultExport,
+        hash: result.outputFiles[0].hash,
+        type: "module",
     };
 }
 

--- a/src/inputs/module.ts
+++ b/src/inputs/module.ts
@@ -54,12 +54,12 @@ export async function loadModule<T>(
      * Run the code and extract the default export
      */
     const defaultExport = runInThisContext(code);
-    return {
-        url: moduleURL,
-        value: defaultExport,
-        hash: result.outputFiles[0].hash,
-        type: "module",
-    };
+    return new TartanInput(
+        defaultExport,
+        moduleURL,
+        result.outputFiles[0].hash,
+        "module",
+    );
 }
 
 /*

--- a/src/phases/discovery.ts
+++ b/src/phases/discovery.ts
@@ -27,7 +27,7 @@ export async function loadContextTreeNode(params: {
      * A logger with transport and format already set up.
      */
     baseLogger: Logger;
-}): Promise<ContextTreeNode<NodeType>> {
+}): Promise<ContextTreeNode> {
     const sourceDirectory = path.resolve(
         params.sourceDirectory ?? params.directory,
     );
@@ -71,42 +71,40 @@ export async function loadContextTreeNode(params: {
     );
 
     logger.info("initializing context objects");
-    const defaultContext: TartanInput<PartialTartanContext> =
-        await initializeContext(
-            { "~source-directory": sourceDirectory, "~this-node": nodePath },
-            defaultContextFile,
-            logger,
-        );
-    const localContext: TartanInput<PartialTartanContext> =
-        await initializeContext(
-            { "~source-directory": sourceDirectory, "~this-node": nodePath },
-            localContextFile,
-            logger,
-        );
+    const defaultContext: PartialTartanContext = await initializeContext(
+        { "~source-directory": sourceDirectory, "~this-node": nodePath },
+        defaultContextFile,
+        logger,
+    );
+    const localContext: PartialTartanContext = await initializeContext(
+        { "~source-directory": sourceDirectory, "~this-node": nodePath },
+        localContextFile,
+        logger,
+    );
 
     const inheritableContext: FullTartanContext = (
-        defaultContext.value.inherit === false
+        defaultContext.inherit === false
             ? {
                   ...params.rootContext,
-                  ...defaultContext.value,
+                  ...defaultContext,
               }
             : {
                   ...params.rootContext,
                   ...params.parentContext,
-                  ...defaultContext.value,
+                  ...defaultContext,
               }
     ) as FullTartanContext;
     const context: FullTartanContext = (
-        defaultContext.value.inherit === false
+        defaultContext.inherit === false
             ? {
                   ...params.rootContext,
-                  ...localContext.value,
+                  ...localContext,
               }
             : {
                   ...params.rootContext,
                   ...params.parentContext,
                   ...inheritableContext,
-                  ...localContext.value,
+                  ...localContext,
               }
     ) as FullTartanContext;
 

--- a/src/phases/output.ts
+++ b/src/phases/output.ts
@@ -1,4 +1,4 @@
-import { OutputtedNode, ResolvedNode } from "../types/nodes.js";
+import { FinalizedNode, OutputtedNode, ResolvedNode } from "../types/nodes.js";
 import fs from "fs/promises";
 import { Dirent } from "node:fs";
 import path from "node:path";
@@ -11,7 +11,7 @@ import { inspect } from "node:util";
  * @argument outputDirectory The root output directory.
  */
 export async function outputNode(
-    rootNode: ResolvedNode,
+    rootNode: FinalizedNode,
     outputDir: string,
 ): Promise<OutputtedNode> {
     /*
@@ -59,10 +59,10 @@ export async function outputNode(
     /*
      * Output the nodes
      */
-    const queue: ResolvedNode[] = [rootNode];
+    const queue: FinalizedNode[] = [rootNode];
 
     while (queue.length > 0) {
-        const node: ResolvedNode = queue.pop() as ResolvedNode;
+        const node: FinalizedNode = queue.pop() as FinalizedNode;
         queue.push(...node.children);
         const logger = node.logger.child({ phase: "output" });
         logger.info(`copying finalized source to ${outputDir}`);

--- a/src/types/inputs.ts
+++ b/src/types/inputs.ts
@@ -1,15 +1,26 @@
 import { URL } from "url";
 
 export type InputType = "module" | "json" | "raw" | "default";
-export type TartanInput<T> = {
-    value: T;
-    /**
-     * the location of the input, as a `file:` url
-     */
-    url: URL;
-    /**
-     * A hash of the input. This is not a specific kind of hash, although the hash should be consistent across input types so that hashes can be meaningfully compared.
-     */
-    hash: string;
-    type: InputType;
-};
+
+export class TartanInput<T> {
+    public value: T;
+    public url: URL;
+    public hash: string;
+    public type: InputType;
+
+    constructor(value: T, url: URL, hash: string, type: InputType) {
+        this.value = value;
+        this.url = url;
+        this.hash = hash;
+        this.type = type;
+    }
+
+    public toJSON() {
+        console.log("JSON WAOW");
+        return {
+            url: this.url.href,
+            hash: this.hash,
+            type: this.type,
+        };
+    }
+}

--- a/src/types/inputs.ts
+++ b/src/types/inputs.ts
@@ -1,9 +1,15 @@
 import { URL } from "url";
 
+export type InputType = "module" | "json" | "raw" | "default";
 export type TartanInput<T> = {
     value: T;
     /**
      * the location of the input, as a `file:` url
      */
     url: URL;
+    /**
+     * A hash of the input. This is not a specific kind of hash, although the hash should be consistent across input types so that hashes can be meaningfully compared.
+     */
+    hash: string;
+    type: InputType;
 };

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -10,7 +10,7 @@ export type NodeType =
     | "handoff.file"
     | "container";
 
-export type ContextTreeNode<T extends NodeType = NodeType> = {
+export type ContextTreeNode = {
     /**
      * The unique ID of this node.
      */
@@ -18,7 +18,7 @@ export type ContextTreeNode<T extends NodeType = NodeType> = {
     /**
      * The type of this node.
      */
-    type: T;
+    type: NodeType;
     /**
      * The path this node is located at, relative to the source directory.
      * May be a directory or a file, depending on the node's type.

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -1,5 +1,6 @@
 import { Logger } from "winston";
 import { FullTartanContext } from "./tartan-context.js";
+import { ReplaceTypes } from "./util.js";
 
 export type NodeType =
     | "page"
@@ -109,13 +110,14 @@ export type ResolvedNode = Omit<ProcessedNode, "outputPath" | "children"> & {
     children: ResolvedNode[];
 };
 
-export type FinalizedNode = ResolvedNode & {
+export type FinalizedNode = Omit<ResolvedNode, "children"> & {
     /**
      * The size in bytes of the finalized output.
      * If this is a container node, size won't be defined.
      * If this is a handoff node, size will be the cumulative size of all files inside the finalized directory.
      */
     size?: number;
+    children: FinalizedNode[];
 };
 
 export type OutputtedNode = {

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -1,6 +1,7 @@
 import { Logger } from "winston";
 import { FullTartanContext } from "./tartan-context.js";
 import { ReplaceTypes } from "./util.js";
+import { TartanInput } from "./inputs.js";
 
 export type NodeType =
     | "page"

--- a/src/types/serialized.ts
+++ b/src/types/serialized.ts
@@ -1,0 +1,76 @@
+import { TartanInput } from "./inputs.js";
+import {
+    ContextTreeNode,
+    ProcessedNode,
+    ResolvedNode,
+    FinalizedNode,
+    OutputtedNode,
+} from "./nodes.js";
+import { SourceProcessor } from "./source-processor.js";
+import { HandoffHandler } from "./handoff-handler.js";
+import { FullTartanContext } from "./tartan-context.js";
+import { ReplaceTypes } from "./util.js";
+
+export type SerializedTartanInput<T> = Omit<TartanInput<T>, "value" | "url"> & {
+    url: string;
+};
+export type SerializedContext = ReplaceTypes<
+    FullTartanContext,
+    {
+        sourceProcessors?: SerializedTartanInput<SourceProcessor>[];
+        handoffHandler?: SerializedTartanInput<HandoffHandler>;
+        assetProcessors?: {
+            [key: string]: SerializedTartanInput<SourceProcessor>[];
+        };
+    }
+>;
+
+export type SerializedContextTreeNode = Omit<
+    ContextTreeNode,
+    "logger" | "sourcePath" | "context" | "inheritableContext" | "children"
+> & {
+    sourcePath: string | undefined;
+    context: SerializedContext;
+    inheritableContext: SerializedContext;
+    children: SerializedContextTreeNode[];
+};
+
+export type SerializedProcessedNode = ReplaceTypes<
+    Omit<ProcessedNode, "logger">,
+    {
+        sourcePath: string | undefined;
+        context: SerializedContext;
+        inheritableContext: SerializedContext;
+        children: SerializedProcessedNode[];
+    }
+>;
+
+export type SerializedResolvedNode = ReplaceTypes<
+    Omit<ResolvedNode, "logger">,
+    {
+        sourcePath: string | undefined;
+        context: SerializedContext;
+        inheritableContext: SerializedContext;
+        children: SerializedResolvedNode[];
+    }
+>;
+
+export type SerializedFinalizedNode = ReplaceTypes<
+    Omit<FinalizedNode, "logger">,
+    {
+        sourcePath: string | undefined;
+        context: SerializedContext;
+        inheritableContext: SerializedContext;
+        children: SerializedResolvedNode[];
+    }
+>;
+
+export type SerializedOutputtedNode = ReplaceTypes<
+    Omit<OutputtedNode, "logger">,
+    {
+        sourcePath: string | undefined;
+        context: SerializedContext;
+        inheritableContext: SerializedContext;
+        children: SerializedResolvedNode[];
+    }
+>;


### PR DESCRIPTION
Really just updated TartanInput to be a class so that I could yeet a `toJSON` function on it. that should be the only thing that isn't already cleanly JSON serializable (outside of, potentially, custom metadata from context objects, but if those aren't serializable I consider it an abuse of metadata lol)